### PR TITLE
Update Dependabot configuration labels for Rust and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels:
-      - "dependencies"
-      - "rust"
+      - "dependencies:rust"
     reviewers:
       - "mrkloan"
     commit-message:
@@ -24,8 +23,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     labels:
-      - "dependencies"
-      - "github-actions"
+      - "dependencies:github-actions"
     reviewers:
       - "mrkloan"
     commit-message:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
     needs: package
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'dependencies:github-actions')
     steps:
       - name: Approve PR
         uses: actions/github-script@v9


### PR DESCRIPTION
Refine the labels in the Dependabot configuration to be more specific for Rust and GitHub Actions dependencies. Adjust the auto-merge condition to exclude PRs labeled with 'dependencies:github-actions'.